### PR TITLE
Added esModuleInterop compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "esModuleInterop": true
     },
     "include": [
         "./src/**/*"


### PR DESCRIPTION
It should be required from Phaser 3.60 on